### PR TITLE
Format and render date

### DIFF
--- a/src/rise-time-date.js
+++ b/src/rise-time-date.js
@@ -142,11 +142,19 @@ export default class RiseTimeDate extends RiseElement {
     return now.format( RiseTimeDate.TIME_FORMATS.get( this.time ) );
   }
 
-  _render( now ) {
-    // TODO: handle rendering date
+  _getDateFormatted( now ) {
+    // TODO: apply specific timezone (if provided)
+    return now.format( this.date );
+  }
 
-    if ( this.type === "time" || this.type === "timedate" ) {
-      this._setOutput( this._getTimeFormatted( now ) );
+  _render( now ) {
+    switch ( this.type ) {
+      case RiseTimeDate.TYPE_TIME:
+        return this._setOutput( this._getTimeFormatted( now ) );
+      case RiseTimeDate.TYPE_DATE:
+        return this._setOutput( this._getDateFormatted( now ) );
+      case RiseTimeDate.TYPE_TIMEDATE:
+        return this._setOutput( `${ this._getTimeFormatted( now )} ${ this._getDateFormatted( now ) }` );
     }
   }
 

--- a/test/integration/rise-time-date.html
+++ b/test/integration/rise-time-date.html
@@ -29,10 +29,22 @@
   </template>
 </test-fixture>
 
+<test-fixture id="test-date-block">
+  <template>
+    <rise-time-date type="date"></rise-time-date>
+  </template>
+</test-fixture>
+
+<test-fixture id="test-timedate-block">
+  <template>
+    <rise-time-date type="timedate"></rise-time-date>
+  </template>
+</test-fixture>
+
 <script type="module">
   suite("rise-data-counter", () => {
     let sandbox = sinon.createSandbox();
-    let elementTime, clock;
+    let elementTime, elementDate, elementTimeDate, clock;
 
     setup(() => {
       RisePlayerConfiguration.Logger = {
@@ -48,6 +60,8 @@
       clock = sinon.useFakeTimers();
 
       elementTime = fixture("test-time-block");
+      elementDate = fixture("test-date-block");
+      elementTimeDate = fixture("test-timedate-block");
     });
 
     teardown(()=>{
@@ -71,6 +85,33 @@
         elementTime.dispatchEvent( new CustomEvent( "start" ) );
 
         assert.equal(elementTime.root.innerHTML, "16:20");
+      } );
+
+      test( "should render date in default format", () => {
+        clock = sinon.useFakeTimers({now: moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm").valueOf()});
+
+        elementDate.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.equal(elementDate.root.innerHTML, "December 15, 2019");
+      } );
+
+      test( "should render date in correct format", () => {
+        clock = sinon.useFakeTimers({now: moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm").valueOf()});
+
+        elementDate.date = "DD/MM/YYYY";
+        elementDate.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.equal(elementDate.root.innerHTML, "15/12/2019");
+      } );
+
+      test( "should render time and date in correct formats", () => {
+        clock = sinon.useFakeTimers({now: moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm").valueOf()});
+
+        elementTimeDate.time = "Hours24";
+        elementTimeDate.date = "MMM DD YYYY";
+        elementTimeDate.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.equal(elementTimeDate.root.innerHTML, "16:20 Dec 15 2019");
       } );
     } );
   });

--- a/test/unit/rise-time-date.html
+++ b/test/unit/rise-time-date.html
@@ -201,6 +201,7 @@
       test( "should cancel the timer", () => {
         clock = sinon.useFakeTimers({now: moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm").valueOf()});
 
+        element.type = "time";
         element._start();
 
         clock.tick(60000);
@@ -363,6 +364,27 @@
         element.time = "Hours24";
 
         assert.equal( element._getTimeFormatted(moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm")), "16:20" );
+      } );
+    } );
+
+    suite( "_getDateFormatted", () => {
+      test( "should return current date in default format", () => {
+        element.type = "date";
+
+        assert.equal( element._getDateFormatted(moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm")), "December 15, 2019" );
+      } );
+
+      test( "should return current date in correct format", () => {
+        element.type = "date";
+        element.date = "MMM DD YYYY";
+
+        assert.equal( element._getDateFormatted(moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm")), "Dec 15 2019" );
+
+        element.date = "MM/DD/YYYY";
+        assert.equal( element._getDateFormatted(moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm")), "12/15/2019" );
+
+        element.date = "DD/MM/YYYY";
+        assert.equal( element._getDateFormatted(moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm")), "15/12/2019" );
       } );
     } );
 


### PR DESCRIPTION
## Description
When configured for `date` or `timedate` types, formatting the current date according to _date_ attribute (or default value) and rendering the value to HTML

## Motivation and Context
Component development

## How Has This Been Tested?
Tested locally via experimenting with demo. Also tested with example template using staged version of component. 

https://apps-stage-8.risevision.com/templates/edit/b38bc817-6acf-4023-a7b1-9b7204838b5f/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
