### PR TITLE
Send data-update event with supporting data

### DIFF
--- a/demo/src/rise-time-date.html
+++ b/demo/src/rise-time-date.html
@@ -29,17 +29,39 @@
       }
     }
   </script>
+  <style>
+    .txtarea {
+      resize: none;
+      border : 1px solid black;
+      width: 300px;
+      height: 200px;
+    }
+  </style>
 </head>
 
 <body>
 
-<rise-time-date id="rise-time-date-01" timezone="America/Los_Angeles">
-</rise-time-date>
+<div id="dataOutput">
+  <p>Data</p>
+  <textarea cols="15" rows="15" class="txtarea"></textarea>
+</div>
+
+<div>
+  <p>Rendered</p>
+  <rise-time-date id="rise-time-date-01">
+  </rise-time-date>
+</div>
+
 
 <script>
   function configureComponents() {
     const riseTimeDate01 = document.querySelector('#rise-time-date-01');
-    console.log('Rise components ready');
+
+    riseTimeDate01.addEventListener( "data-update", evt => {
+      const dataOutput = document.querySelector( "#dataOutput textarea" );
+
+      dataOutput.value = JSON.stringify(evt.detail);
+    } );
 
     riseTimeDate01.addEventListener( "data-error", evt => {
       console.log( "data-error", evt.detail );

--- a/test/integration/rise-time-date.html
+++ b/test/integration/rise-time-date.html
@@ -127,6 +127,79 @@
       } );
     } );
 
+    suite( "data event", () => {
+      test( "should receive data event immediately after component starts", (done) => {
+        const handler = function( evt ) {
+          assert.isObject( evt.detail );
+          assert.equal( evt.detail.type, "timedate" );
+          assert.equal( evt.detail.date, "December 15, 2019" );
+          assert.isObject( evt.detail.time );
+          assert.deepEqual( evt.detail.time, {
+            formatted: "4:20 PM",
+            units: {
+              hour: 4,
+              minute: 20,
+              second: 0,
+              meridiem: "PM"
+            }
+          } );
+          assert.isObject( evt.detail.user );
+          assert.deepEqual( evt.detail.user, {
+            dateFormat: "MMMM DD, YYYY",
+            timeFormat: "Hours12",
+            timezone: null
+          } );
+
+          done();
+        };
+
+        clock = sinon.useFakeTimers({now: moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm").valueOf()});
+
+        elementTimeDate.addEventListener( "data-update", handler );
+        elementTimeDate.dispatchEvent( new CustomEvent( "start" ) );
+      } );
+
+      test( "should receive data events per refresh", ( done ) => {
+        const handler = function( evt ) {
+          dataCount += 1;
+
+          if (dataCount === 2) {
+            assert.isObject( evt.detail );
+            assert.equal( evt.detail.type, "timedate" );
+            assert.equal( evt.detail.date, "December 15, 2019" );
+            assert.isObject( evt.detail.time );
+            assert.deepEqual( evt.detail.time, {
+              formatted: "4:20 PM",
+              units: {
+                hour: 4,
+                minute: 20,
+                second: 1,
+                meridiem: "PM"
+              }
+            } );
+            assert.isObject( evt.detail.user );
+            assert.deepEqual( evt.detail.user, {
+              dateFormat: "MMMM DD, YYYY",
+              timeFormat: "Hours12",
+              timezone: null
+            } );
+
+            done();
+          }
+
+        };
+
+        let dataCount = 0;
+
+        clock = sinon.useFakeTimers({now: moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm").valueOf()});
+
+        elementTimeDate.addEventListener( "data-update", handler );
+        elementTimeDate.dispatchEvent( new CustomEvent( "start" ) );
+
+        clock.tick(1000);
+      } );
+    } );
+
   });
 </script>
 </body>

--- a/test/unit/rise-time-date.html
+++ b/test/unit/rise-time-date.html
@@ -367,6 +367,54 @@
       } );
     } );
 
+    suite( "_get12HourValue", () => {
+      test( "should return correct 12 hour value", () => {
+        element.type = "time";
+        element.time = "Hours12";
+
+        assert.equal( element._get12HourValue(moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm")), 4 );
+        assert.equal( element._get12HourValue(moment("2019-12-15T04:20", "YYYY-MM-DDTHH:mm")), 4 );
+        assert.equal( element._get12HourValue(moment("2019-12-15T23:45", "YYYY-MM-DDTHH:mm")), 11 );
+        assert.equal( element._get12HourValue(moment("2019-12-15T11:45", "YYYY-MM-DDTHH:mm")), 11 );
+        assert.equal( element._get12HourValue(moment("2019-12-15T12:10", "YYYY-MM-DDTHH:mm")), 12 );
+        assert.equal( element._get12HourValue(moment("2019-12-15T00:10", "YYYY-MM-DDTHH:mm")), 12 );
+        assert.equal( element._get12HourValue(moment("2019-12-15T13:30", "YYYY-MM-DDTHH:mm")), 1 );
+        assert.equal( element._get12HourValue(moment("2019-12-15T01:30", "YYYY-MM-DDTHH:mm")), 1 );
+      } );
+    } );
+
+    suite( "_getTimeData", () => {
+      test( "should return correct data when time format is 'Hours12'", () => {
+        element.type = "time";
+        element.time = "Hours12";
+
+        assert.deepEqual( element._getTimeData(moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm")), {
+          formatted: "4:20 PM",
+          units: {
+            hour: 4,
+            minute: 20,
+            second: 0,
+            meridiem: "PM"
+          }
+        } );
+      } );
+
+      test( "should return correct data when time format is 'Hours24'", () => {
+        element.type = "time";
+        element.time = "Hours24";
+
+        assert.deepEqual( element._getTimeData(moment("2019-12-15T16:20", "YYYY-MM-DDTHH:mm")), {
+          formatted: "16:20",
+          units: {
+            hour: 16,
+            minute: 20,
+            second: 0
+          }
+        } );
+      } );
+
+    } );
+
     suite( "_getDateFormatted", () => {
       test( "should return current date in default format", () => {
         element.type = "date";
@@ -405,7 +453,8 @@
     suite( "_processTimeDate", () => {
       // TODO: test that event is sent with data
 
-      test( "should render and run timer", () => {
+      test( "should send 'data-update' event, render and run timer", () => {
+        sandbox.stub(element, "_sendTimeDateEvent");
         sandbox.stub(element, "_render");
         sandbox.stub(element, "_runTimer");
 
@@ -417,6 +466,10 @@
         element.time = "Hours12";
 
         element._processTimeDate();
+
+        assert.isTrue( element._sendTimeDateEvent.calledOnce );
+        assert.equal( element._sendTimeDateEvent.args[0][0], "data-update" );
+        assert.isObject( element._sendTimeDateEvent.args[0][1] );
 
         assert.isTrue( element._render.calledOnce );
         assert.isObject( element._render.args[0][0] );

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -16,7 +16,7 @@
       ],
       "thresholds": {
         "global": {
-          "branches": 85,
+          "branches": 95,
           "lines": 95,
           "functions": 95,
           "statements": 95


### PR DESCRIPTION
## Description
Send _data-update_ event upon every processing time and/or date every 1 second interval. 

Providing full supporting data for time and/or date. Example structure with values:

```
{ 
  type: "timedate",
  date: "December 15, 2019",
  time: {
    formatted: "4:20 PM",
    units: { 
      hour: 4,
      minute: 20,
      second: 0,
      meridiem: "PM",
     }
  },
  user: {
    dateFormat: "MMMM DD, YYYY",
    timeFormat: "Hours12",
    timezone: null,
  }
}
```

Updated demo to output data from _data-update_ event

## Motivation and Context
Component development

## How Has This Been Tested?
Experimented and validated with demo

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
