### PR TITLE
Use timezone when providing time object in data-update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: |
-          VERSION=$(cat version-string/version)
+          VERSION=2019.12.26.18.51
           TARGET=$WIDGETS_BASE/staging/components/$COMPONENT_NAME/$VERSION/
           echo Deploying version $VERSION to $COMPONENT_NAME
           node_modules/rise-common-component/scripts/deploy-gcs.sh $COMPONENT_NAME $TARGET

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: |
-          VERSION=2019.12.26.18.51
+          VERSION=$(cat version-string/version)
           TARGET=$WIDGETS_BASE/staging/components/$COMPONENT_NAME/$VERSION/
           echo Deploying version $VERSION to $COMPONENT_NAME
           node_modules/rise-common-component/scripts/deploy-gcs.sh $COMPONENT_NAME $TARGET

--- a/src/rise-time-date.js
+++ b/src/rise-time-date.js
@@ -147,7 +147,7 @@ export default class RiseTimeDate extends RiseElement {
 
   _get12HourValue( provided ) {
     const now = this.timezone ? provided.tz( this.timezone ) : provided;
-    const hour = moment(now.valueOf() ).format("h");
+    const hour = now.format("h");
 
     return parseInt( hour, 10 );
   }

--- a/src/rise-time-date.js
+++ b/src/rise-time-date.js
@@ -145,11 +145,8 @@ export default class RiseTimeDate extends RiseElement {
     }
   }
 
-  _get12HourValue( provided ) {
-    const now = this.timezone ? provided.tz( this.timezone ) : provided;
-    const hour = now.format("h");
-
-    return parseInt( hour, 10 );
+  _get12HourValue( now ) {
+    return parseInt( now.format("h"), 10 );
   }
 
   _getTimeFormatted( now ) {

--- a/src/rise-time-date.js
+++ b/src/rise-time-date.js
@@ -145,7 +145,8 @@ export default class RiseTimeDate extends RiseElement {
     }
   }
 
-  _get12HourValue( now ) {
+  _get12HourValue( provided ) {
+    const now = this.timezone ? provided.tz( this.timezone ) : provided;
     const hour = moment(now.valueOf() ).format("h");
 
     return parseInt( hour, 10 );


### PR DESCRIPTION
## Description
The time object provided in `data-update` event was not using timezone information correctly. 

## Motivation and Context
Designers may want to handle events for custom purposes and they need timezone to be considered.

## How Has This Been Tested?
It can be tested here: https://apps-stage-7.risevision.com/templates/edit/1ecad5fe-6a49-45b0-8c29-4ce7037c7e64/?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d

Switching Time Format and Timezone in the last instance should reflect the correct hour independently of format.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@santiagonoguez please review
