### PR TITLE
updates readme for non-editable functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This component receives the following list of attributes:
 - **date**: (string / optional): The specific format to use for displaying the current date. Valid formats are `MMMM DD, YYYY`, `MMM DD YYYY`, `MM/DD/YYYY`, and `DD/MM/YYYY`. Defaults to `MMMM DD, YYYY`.
 - **time**: (string / optional): The time format in terms of hours to use for displaying the current time. Valid formats are `Hours12` and `Hours24`. Defaults to `Hours12`.
 - **timezone**: (string / optional): The specific timezone to use for formatting date and/or time (for example, `US/Eastern`). Valid values will be determined by checking the existence of the value in Moment's Timezone list of timezone names (an unofficial list can be found [here](https://gist.github.com/diogocapela/12c6617fc87607d11fd62d2a4f42b02a)). Defaults to the local machine's timezone.
- - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the Template Editor and will also require the following lines (replacing with the appropriate element id):
+ - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the Template Editor and will also require the following lines (replacing with the appropriate element id) because the instance will require receiving a forced `start` event:
 
 ```
 const riseTimeDate01 = document.querySelector('#rise-time-date-01');

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ This component receives the following list of attributes:
 - **date**: (string / optional): The specific format to use for displaying the current date. Valid formats are `MMMM DD, YYYY`, `MMM DD YYYY`, `MM/DD/YYYY`, and `DD/MM/YYYY`. Defaults to `MMMM DD, YYYY`.
 - **time**: (string / optional): The time format in terms of hours to use for displaying the current time. Valid formats are `Hours12` and `Hours24`. Defaults to `Hours12`.
 - **timezone**: (string / optional): The specific timezone to use for formatting date and/or time (for example, `US/Eastern`). Valid values will be determined by checking the existence of the value in Moment's Timezone list of timezone names (an unofficial list can be found [here](https://gist.github.com/diogocapela/12c6617fc87607d11fd62d2a4f42b02a)). Defaults to the local machine's timezone.
- - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the Template Editor.
+ - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the Template Editor and will also require the following lines (replacing with the appropriate element id):
+
+```
+const riseTimeDate01 = document.querySelector('#rise-time-date-01');
+
+RisePlayerConfiguration.Helpers.sendStartEvent( riseTimeDate01 );
+```
 
 This component does not support PUD; it will need to be handled by Designers on a per Template basis.
 


### PR DESCRIPTION
@fjvallarino @stulees I had to change an instance of a time and date component to non-editable and noticed that without the helper function it didn't show locally or in the editor. I think in non-editable it needs the helper function to run (like with the financial components) so I have updated the README to include this in case someone else runs into this. Thanks!

## Description
Updating README doc to include steps to run in non-editable mode.

## Motivation and Context
Complete documentation for designers

## How Has This Been Tested?
Staging player (to validate change)

## Release Plan:
Update to README, no version change

#### Release Checklist Items Skipped?
N/A
