### PR TITLE
Add new dist file that points to polymer-bundle.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,14 +1,20 @@
 const concat = require("gulp-concat");
 const gulp = require("gulp");
 
-const bundle = "dist/rise-time-date.js";
+const bundles = [ 
+	"dist/rise-time-date.js",
+	"dist/rise-time-date-bundle.min.js"
+];
 const dependencies = [
   "node_modules/moment/min/moment.min.js",
   "node_modules/moment-timezone-with-data-2010-2020/index.js"
 ];
 
-gulp.task( "default", () => {
-  return gulp.src( dependencies.concat(bundle) )
-    .pipe( concat( bundle ) )
-    .pipe( gulp.dest( "." ) );
+gulp.task( "default", (done) => {
+  bundles.map(function(file) {
+    return gulp.src( dependencies.concat( file ) )
+      .pipe( concat( file ) )
+      .pipe( gulp.dest( "." ) );
+  });
+  done();
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-time-date",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Rise time & date component",
   "scripts": {
     "prebuild": "eslint .",
@@ -30,7 +30,7 @@
   "dependencies": {
     "moment": "^2.24.0",
     "moment-timezone-with-data-2010-2020": "^0.4.0",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.1"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.2"
   },
   "devDependencies": {
     "eslint-utils": ">=1.4.1",


### PR DESCRIPTION
## Description
Adds an extra distribution file that references a static version of polymer and dependencies instead of relative to the template.

## Motivation and Context
Please check notes from: https://github.com/Rise-Vision/rise-common-component/pull/73

## How Has This Been Tested?
Confirmed the file exists and points to the static polymer-bundle: 
https://widgets.risevision.com/staging/components/rise-time-date/build-bundle/rise-time-date-bundle.min.js

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alexdeaconu Please review. 
@stulees @olegrise fyi

